### PR TITLE
Copy Views

### DIFF
--- a/src/mask.rs
+++ b/src/mask.rs
@@ -89,4 +89,3 @@ pub trait Mask {
         list.concat()
     }
 }
-

--- a/src/replication/manager.rs
+++ b/src/replication/manager.rs
@@ -127,7 +127,7 @@ impl ReplicationManager {
         // We do this after all the other data has transferred to prevent the overhead
         // of validations on every insert
         println!("Copying Indexes...");
-        
+
         let copy_index_handles: Vec<_> = self
             .processors
             .into_iter()
@@ -148,7 +148,7 @@ impl ReplicationManager {
         // Copy views if enabled
         if self.config.copy_views {
             println!("Copying Views...");
-            
+
             // Get all source views to copy
             let source_views = match self.dbs.list_source_views().await {
                 Ok(views) => views,
@@ -166,10 +166,7 @@ impl ReplicationManager {
                         let dbs = Arc::clone(&self.dbs);
                         tokio::spawn(async move {
                             if let Err(e) = dbs.copy_single_view(&view_spec).await {
-                                println!(
-                                    "Error copying view '{}': {:?}",
-                                    view_spec.name, e
-                                );
+                                println!("Error copying view '{}': {:?}", view_spec.name, e);
                             } else {
                                 println!("Successfully copied view: {}", view_spec.name);
                             }

--- a/src/replication/manager_builder.rs
+++ b/src/replication/manager_builder.rs
@@ -233,14 +233,16 @@ impl ReplicationManagerBuilder {
             .iter()
             .map(|p| p.collection_name().to_string())
             .collect();
-        
+
         // Add view names if view copying is enabled
         if self.config.copy_views {
-            let view_names = dbs.get_source_view_names().await
+            let view_names = dbs
+                .get_source_view_names()
+                .await
                 .expect("Expected to successfully get source view names");
             items_to_drop.extend(view_names);
         }
-        
+
         dbs.clear_target_collections(&items_to_drop)
             .await
             .expect("Expected to successfully drop target database collections and views before replication");

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -3,4 +3,3 @@ pub(crate) mod manager_builder;
 pub(crate) mod processor;
 pub(crate) mod task;
 pub(crate) mod types;
-

--- a/src/replication/types.rs
+++ b/src/replication/types.rs
@@ -1,4 +1,4 @@
-use crate::TuxedoResult;
+use crate::{TuxedoError, TuxedoResult};
 use bson::{doc, Document};
 use futures_util::TryStreamExt;
 use mongodb::options::{FindOptions, InsertManyOptions};
@@ -8,183 +8,244 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 #[derive(Debug)]
 pub(crate) struct DatabasePair {
-    source: Database,
-    target: Database,
+	source: Database,
+	target: Database,
 }
 
 impl DatabasePair {
-    pub(crate) fn new(source: Database, target: Database) -> Self {
-        Self { source, target }
-    }
+	pub(crate) fn new(source: Database, target: Database) -> Self {
+		Self { source, target }
+	}
 
-    pub(crate) async fn read<T: Serialize + DeserializeOwned + Unpin + Send + Sync>(
-        &self,
-        collection_name: &str,
-        query: Document,
-        options: Option<FindOptions>,
-    ) -> TuxedoResult<Cursor<T>> {
-        Ok(self
-            .source
-            .collection::<T>(collection_name)
-            .find(query)
-            .with_options(options)
-            .await?)
-    }
+	pub(crate) async fn read<T: Serialize + DeserializeOwned + Unpin + Send + Sync>(
+		&self,
+		collection_name: &str,
+		query: Document,
+		options: Option<FindOptions>,
+	) -> TuxedoResult<Cursor<T>> {
+		Ok(self
+			.source
+			.collection::<T>(collection_name)
+			.find(query)
+			.with_options(options)
+			.await?)
+	}
 
-    pub(crate) async fn get_average_document_size(&self, collection_name: &str) -> TuxedoResult<u64> {
-        let stats = self
-            .source
-            .run_command(doc! { "collStats": collection_name })
-            .await?;
+	pub(crate) async fn get_average_document_size(&self, collection_name: &str) -> TuxedoResult<u64> {
+		let stats = self
+			.source
+			.run_command(doc! { "collStats": collection_name })
+			.await?;
 
-        let avg_doc_size = stats.get_f64("avgObjSize").unwrap_or(1024.0);
-        Ok(avg_doc_size as u64)
-    }
+		let avg_doc_size = stats.get_f64("avgObjSize").unwrap_or(1024.0);
+		Ok(avg_doc_size as u64)
+	}
 
-    pub(crate) async fn read_documents(
-        &self,
-        collection_name: &str,
-        query: Document,
-        options: Option<FindOptions>,
-    ) -> TuxedoResult<Cursor<Document>> {
-        Ok(self
-            .source
-            .collection::<Document>(collection_name)
-            .find(query)
-            .with_options(options)
-            .await?)
-    }
+	pub(crate) async fn read_documents(
+		&self,
+		collection_name: &str,
+		query: Document,
+		options: Option<FindOptions>,
+	) -> TuxedoResult<Cursor<Document>> {
+		Ok(self
+			.source
+			.collection::<Document>(collection_name)
+			.find(query)
+			.with_options(options)
+			.await?)
+	}
 
-    pub(crate) async fn read_total_documents<T: Send + Sync>(
-        &self,
-        collection_name: &str,
-        query: Document,
-    ) -> TuxedoResult<usize> {
-        let total_documents = self
-            .source
-            .collection::<T>(collection_name)
-            .count_documents(query)
-            .await? as usize;
-        Ok(total_documents)
-    }
+	pub(crate) async fn read_total_documents<T: Send + Sync>(
+		&self,
+		collection_name: &str,
+		query: Document,
+	) -> TuxedoResult<usize> {
+		let total_documents = self
+			.source
+			.collection::<T>(collection_name)
+			.count_documents(query)
+			.await? as usize;
+		Ok(total_documents)
+	}
 
-    pub(crate) async fn write<T: Send + Sync + Serialize>(
-        &self,
-        collection_name: &str,
-        records: &[T],
-        options: Option<InsertManyOptions>,
-    ) -> TuxedoResult<()> {
-        self.target
-            .collection::<T>(collection_name)
-            .insert_many(records)
-            .with_options(options)
-            .await?;
-        Ok(())
-    }
+	pub(crate) async fn write<T: Send + Sync + Serialize>(
+		&self,
+		collection_name: &str,
+		records: &[T],
+		options: Option<InsertManyOptions>,
+	) -> TuxedoResult<()> {
+		self.target
+			.collection::<T>(collection_name)
+			.insert_many(records)
+			.with_options(options)
+			.await?;
+		Ok(())
+	}
 
-    // Indexes
+	// Indexes
 
-    /// Copies the indexes from the source collection to the equivilant target collection
-    pub(crate) async fn copy_indexes(&self, collection_name: &str) -> TuxedoResult<()> {
-        let mut source_index_cursor = self
-            .source
-            .collection::<Document>(collection_name)
-            .list_indexes()
-            .await?;
+	/// Copies the indexes from the source collection to the equivilant target collection
+	pub(crate) async fn copy_indexes(&self, collection_name: &str) -> TuxedoResult<()> {
+		let mut source_index_cursor = self
+			.source
+			.collection::<Document>(collection_name)
+			.list_indexes()
+			.await?;
 
-        let mut indexes: Vec<IndexModel> = Vec::new();
-        while let Some(index) = source_index_cursor.try_next().await? {
-            // Skip the _id index as it's created automatically
-            if index.keys.get("_id").is_some() {
-                continue;
-            }
+		let mut indexes: Vec<IndexModel> = Vec::new();
+		while let Some(index) = source_index_cursor.try_next().await? {
+			// Skip the _id index as it's created automatically
+			if index.keys.get("_id").is_some() {
+				continue;
+			}
 
-            indexes.push(index);
-        }
+			indexes.push(index);
+		}
 
-        self.target
-            .collection::<Document>(collection_name)
-            .create_indexes(indexes)
-            .await?;
-        Ok(())
-    }
+		if indexes.is_empty() {
+			println!("  -> No indexes to copy for '{}'", collection_name);
+			return Ok(());
+		}
 
-    // Database Initialization (testing) functions
+		self
+			.target
+			.collection::<Document>(collection_name)
+			.create_indexes(indexes)
+			.await?;
 
-    pub(crate) async fn clear_target_collections(
-        &self,
-        collection_names: &[String],
-    ) -> TuxedoResult<()> {
-        let target_collections = self.target.list_collection_names().await?;
+		Ok(())
+	}
 
-        println!("******************************");
-        for collection_name in target_collections.into_iter() {
-            // Skip system collections:
-            // 1. Collections with system.* prefix
-            // 2. Collections in admin database
-            // 3. Collections in config database
-            // 4. Special system collections
-            if collection_name.starts_with("system.")
-                || collection_name.starts_with("admin.")
-                || collection_name.starts_with("config.")
-            {
-                println!("Skipping system collection: {}", collection_name);
-                continue;
-            }
+	// Database Initialization (testing) functions
 
-            // Only drop collections that are in our processor list
-            if collection_names.contains(&collection_name) {
-                println!("Dropping collection: {}", collection_name);
-                self.target
-                    .collection::<mongodb::bson::Document>(&collection_name)
-                    .drop()
-                    .await?;
-            } else {
-                println!(
-                    "Skipping collection not in processor list: {}",
-                    collection_name
-                );
-            }
-        }
-        println!("******************************");
-        println!("Target database collections have been selectively dropped.\n\n");
-        Ok(())
-    }
+	pub(crate) async fn clear_target_collections(
+		&self,
+		collection_names: &[String],
+	) -> TuxedoResult<()> {
+		let target_collections = self.target.list_collection_names().await?;
 
-    pub(crate) async fn test_database_collection_source(&self) -> TuxedoResult<()> {
-        self.test_database_connection(&self.source).await
-    }
+		println!("******************************");
+		for collection_name in target_collections.into_iter() {
+			// Skip system collections:
+			// 1. Collections with system.* prefix
+			// 2. Collections in admin database
+			// 3. Collections in config database
+			// 4. Special system collections
+			if collection_name.starts_with("system.")
+				|| collection_name.starts_with("admin.")
+				|| collection_name.starts_with("config.")
+			{
+				println!("Skipping system collection: {}", collection_name);
+				continue;
+			}
 
-    pub(crate) async fn test_database_collection_target(&self) -> TuxedoResult<()> {
-        self.test_database_connection(&self.target).await
-    }
+			// Only drop collections that are in our list (collections + views)
+			if collection_names.contains(&collection_name) {
+				println!("Dropping collection/view: {}", collection_name);
+				self.target
+					.collection::<mongodb::bson::Document>(&collection_name)
+					.drop()
+					.await?;
+			} else {
+				println!(
+					"Skipping collection not in drop list: {}",
+					collection_name
+				);
+			}
+		}
+		println!("******************************");
+		println!("Target database collections and views have been selectively dropped.\n\n");
+		Ok(())
+	}
 
-    async fn test_database_connection(&self, db: &Database) -> TuxedoResult<()> {
-        db.list_collection_names()
-            .await
-            .expect("Failed to list connections for DB");
-        Ok(())
-    }
+	pub(crate) async fn test_database_collection_source(&self) -> TuxedoResult<()> {
+		self.test_database_connection(&self.source).await
+	}
+
+	pub(crate) async fn test_database_collection_target(&self) -> TuxedoResult<()> {
+		self.test_database_connection(&self.target).await
+	}
+
+	async fn test_database_connection(&self, db: &Database) -> TuxedoResult<()> {
+		db.list_collection_names()
+			.await
+			.expect("Failed to list connections for DB");
+		Ok(())
+	}
+
+	// Views
+
+	/// Gets the names of all views in the source database
+	pub(crate) async fn get_source_view_names(&self) -> TuxedoResult<Vec<String>> {
+		let views = self.list_source_views().await?;
+		Ok(views.into_iter().map(|view| view.name).collect())
+	}
+
+	/// Lists all views in the source database for copying
+	pub(crate) async fn list_source_views(&self) -> TuxedoResult<Vec<mongodb::results::CollectionSpecification>> {
+		let filter = doc! { "type": "view" };
+		let mut cursor = self.source.list_collections().filter(filter).await?;
+		
+		let mut views = Vec::new();
+		while let Some(collection_spec) = cursor.try_next().await? {
+			// Verify this is actually a view with the required fields
+			if collection_spec.options.view_on.is_some() && collection_spec.options.pipeline.is_some() {
+				views.push(collection_spec);
+			} else {
+				println!(
+					"Warning: Collection '{}' marked as view but missing view fields",
+					collection_spec.name
+				);
+			}
+		}
+		
+		if !views.is_empty() {
+			println!("Found {} views to copy", views.len());
+		}
+		
+		Ok(views)
+	}
+
+	/// Copies a single view from source to target (used by manager tasks)
+	/// Note: Target views are cleared at startup, so no existence check needed
+	pub(crate) async fn copy_single_view(&self, view_spec: &mongodb::results::CollectionSpecification) -> TuxedoResult<()> {
+		// Extract view information from the CollectionSpecification
+		let view_on = view_spec.options.view_on.as_ref()
+			.ok_or_else(|| TuxedoError::Generic(format!("View '{}' missing viewOn", view_spec.name)))?;
+		
+		let pipeline = view_spec.options.pipeline.as_ref()
+			.ok_or_else(|| TuxedoError::Generic(format!("View '{}' missing pipeline", view_spec.name)))?;
+
+		// Create the view using the createView command
+		let create_view_command = doc! {
+			"create": &view_spec.name,
+			"viewOn": view_on,
+			"pipeline": pipeline,
+		};
+
+		self.target.run_command(create_view_command).await?;
+		Ok(())
+	}
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ReplicationStrategy {
-    Clone,
-    Mask,
+	Clone,
+	Mask,
 }
 
 impl TryFrom<String> for ReplicationStrategy {
-    type Error = String;
+	type Error = String;
 
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        match value.to_lowercase().as_str() {
-            "clone" => Ok(Self::Clone),
-            "mask" => Ok(Self::Mask),
-            other => Err(format!(
-                "{} is not a supported replication strategy.",
-                other
-            )),
-        }
-    }
+	fn try_from(value: String) -> Result<Self, Self::Error> {
+		match value.to_lowercase().as_str() {
+			"clone" => Ok(Self::Clone),
+			"mask" => Ok(Self::Mask),
+			other => Err(format!(
+				"{} is not a supported replication strategy.",
+				other
+			)),
+		}
+	}
 }

--- a/src/replication/types.rs
+++ b/src/replication/types.rs
@@ -8,244 +8,252 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 #[derive(Debug)]
 pub(crate) struct DatabasePair {
-	source: Database,
-	target: Database,
+    source: Database,
+    target: Database,
 }
 
 impl DatabasePair {
-	pub(crate) fn new(source: Database, target: Database) -> Self {
-		Self { source, target }
-	}
+    pub(crate) fn new(source: Database, target: Database) -> Self {
+        Self { source, target }
+    }
 
-	pub(crate) async fn read<T: Serialize + DeserializeOwned + Unpin + Send + Sync>(
-		&self,
-		collection_name: &str,
-		query: Document,
-		options: Option<FindOptions>,
-	) -> TuxedoResult<Cursor<T>> {
-		Ok(self
-			.source
-			.collection::<T>(collection_name)
-			.find(query)
-			.with_options(options)
-			.await?)
-	}
+    pub(crate) async fn read<T: Serialize + DeserializeOwned + Unpin + Send + Sync>(
+        &self,
+        collection_name: &str,
+        query: Document,
+        options: Option<FindOptions>,
+    ) -> TuxedoResult<Cursor<T>> {
+        Ok(self
+            .source
+            .collection::<T>(collection_name)
+            .find(query)
+            .with_options(options)
+            .await?)
+    }
 
-	pub(crate) async fn get_average_document_size(&self, collection_name: &str) -> TuxedoResult<u64> {
-		let stats = self
-			.source
-			.run_command(doc! { "collStats": collection_name })
-			.await?;
+    pub(crate) async fn get_average_document_size(
+        &self,
+        collection_name: &str,
+    ) -> TuxedoResult<u64> {
+        let stats = self
+            .source
+            .run_command(doc! { "collStats": collection_name })
+            .await?;
 
-		let avg_doc_size = stats.get_f64("avgObjSize").unwrap_or(1024.0);
-		Ok(avg_doc_size as u64)
-	}
+        let avg_doc_size = stats.get_f64("avgObjSize").unwrap_or(1024.0);
+        Ok(avg_doc_size as u64)
+    }
 
-	pub(crate) async fn read_documents(
-		&self,
-		collection_name: &str,
-		query: Document,
-		options: Option<FindOptions>,
-	) -> TuxedoResult<Cursor<Document>> {
-		Ok(self
-			.source
-			.collection::<Document>(collection_name)
-			.find(query)
-			.with_options(options)
-			.await?)
-	}
+    pub(crate) async fn read_documents(
+        &self,
+        collection_name: &str,
+        query: Document,
+        options: Option<FindOptions>,
+    ) -> TuxedoResult<Cursor<Document>> {
+        Ok(self
+            .source
+            .collection::<Document>(collection_name)
+            .find(query)
+            .with_options(options)
+            .await?)
+    }
 
-	pub(crate) async fn read_total_documents<T: Send + Sync>(
-		&self,
-		collection_name: &str,
-		query: Document,
-	) -> TuxedoResult<usize> {
-		let total_documents = self
-			.source
-			.collection::<T>(collection_name)
-			.count_documents(query)
-			.await? as usize;
-		Ok(total_documents)
-	}
+    pub(crate) async fn read_total_documents<T: Send + Sync>(
+        &self,
+        collection_name: &str,
+        query: Document,
+    ) -> TuxedoResult<usize> {
+        let total_documents = self
+            .source
+            .collection::<T>(collection_name)
+            .count_documents(query)
+            .await? as usize;
+        Ok(total_documents)
+    }
 
-	pub(crate) async fn write<T: Send + Sync + Serialize>(
-		&self,
-		collection_name: &str,
-		records: &[T],
-		options: Option<InsertManyOptions>,
-	) -> TuxedoResult<()> {
-		self.target
-			.collection::<T>(collection_name)
-			.insert_many(records)
-			.with_options(options)
-			.await?;
-		Ok(())
-	}
+    pub(crate) async fn write<T: Send + Sync + Serialize>(
+        &self,
+        collection_name: &str,
+        records: &[T],
+        options: Option<InsertManyOptions>,
+    ) -> TuxedoResult<()> {
+        self.target
+            .collection::<T>(collection_name)
+            .insert_many(records)
+            .with_options(options)
+            .await?;
+        Ok(())
+    }
 
-	// Indexes
+    // Indexes
 
-	/// Copies the indexes from the source collection to the equivilant target collection
-	pub(crate) async fn copy_indexes(&self, collection_name: &str) -> TuxedoResult<()> {
-		let mut source_index_cursor = self
-			.source
-			.collection::<Document>(collection_name)
-			.list_indexes()
-			.await?;
+    /// Copies the indexes from the source collection to the equivilant target collection
+    pub(crate) async fn copy_indexes(&self, collection_name: &str) -> TuxedoResult<()> {
+        let mut source_index_cursor = self
+            .source
+            .collection::<Document>(collection_name)
+            .list_indexes()
+            .await?;
 
-		let mut indexes: Vec<IndexModel> = Vec::new();
-		while let Some(index) = source_index_cursor.try_next().await? {
-			// Skip the _id index as it's created automatically
-			if index.keys.get("_id").is_some() {
-				continue;
-			}
+        let mut indexes: Vec<IndexModel> = Vec::new();
+        while let Some(index) = source_index_cursor.try_next().await? {
+            // Skip the _id index as it's created automatically
+            if index.keys.get("_id").is_some() {
+                continue;
+            }
 
-			indexes.push(index);
-		}
+            indexes.push(index);
+        }
 
-		if indexes.is_empty() {
-			println!("  -> No indexes to copy for '{}'", collection_name);
-			return Ok(());
-		}
+        if indexes.is_empty() {
+            println!("  -> No indexes to copy for '{}'", collection_name);
+            return Ok(());
+        }
 
-		self
-			.target
-			.collection::<Document>(collection_name)
-			.create_indexes(indexes)
-			.await?;
+        self.target
+            .collection::<Document>(collection_name)
+            .create_indexes(indexes)
+            .await?;
 
-		Ok(())
-	}
+        Ok(())
+    }
 
-	// Database Initialization (testing) functions
+    // Database Initialization (testing) functions
 
-	pub(crate) async fn clear_target_collections(
-		&self,
-		collection_names: &[String],
-	) -> TuxedoResult<()> {
-		let target_collections = self.target.list_collection_names().await?;
+    pub(crate) async fn clear_target_collections(
+        &self,
+        collection_names: &[String],
+    ) -> TuxedoResult<()> {
+        let target_collections = self.target.list_collection_names().await?;
 
-		println!("******************************");
-		for collection_name in target_collections.into_iter() {
-			// Skip system collections:
-			// 1. Collections with system.* prefix
-			// 2. Collections in admin database
-			// 3. Collections in config database
-			// 4. Special system collections
-			if collection_name.starts_with("system.")
-				|| collection_name.starts_with("admin.")
-				|| collection_name.starts_with("config.")
-			{
-				println!("Skipping system collection: {}", collection_name);
-				continue;
-			}
+        println!("******************************");
+        for collection_name in target_collections.into_iter() {
+            // Skip system collections:
+            // 1. Collections with system.* prefix
+            // 2. Collections in admin database
+            // 3. Collections in config database
+            // 4. Special system collections
+            if collection_name.starts_with("system.")
+                || collection_name.starts_with("admin.")
+                || collection_name.starts_with("config.")
+            {
+                println!("Skipping system collection: {}", collection_name);
+                continue;
+            }
 
-			// Only drop collections that are in our list (collections + views)
-			if collection_names.contains(&collection_name) {
-				println!("Dropping collection/view: {}", collection_name);
-				self.target
-					.collection::<mongodb::bson::Document>(&collection_name)
-					.drop()
-					.await?;
-			} else {
-				println!(
-					"Skipping collection not in drop list: {}",
-					collection_name
-				);
-			}
-		}
-		println!("******************************");
-		println!("Target database collections and views have been selectively dropped.\n\n");
-		Ok(())
-	}
+            // Only drop collections that are in our list (collections + views)
+            if collection_names.contains(&collection_name) {
+                println!("Dropping collection/view: {}", collection_name);
+                self.target
+                    .collection::<mongodb::bson::Document>(&collection_name)
+                    .drop()
+                    .await?;
+            } else {
+                println!("Skipping collection not in drop list: {}", collection_name);
+            }
+        }
+        println!("******************************");
+        println!("Target database collections and views have been selectively dropped.\n\n");
+        Ok(())
+    }
 
-	pub(crate) async fn test_database_collection_source(&self) -> TuxedoResult<()> {
-		self.test_database_connection(&self.source).await
-	}
+    pub(crate) async fn test_database_collection_source(&self) -> TuxedoResult<()> {
+        self.test_database_connection(&self.source).await
+    }
 
-	pub(crate) async fn test_database_collection_target(&self) -> TuxedoResult<()> {
-		self.test_database_connection(&self.target).await
-	}
+    pub(crate) async fn test_database_collection_target(&self) -> TuxedoResult<()> {
+        self.test_database_connection(&self.target).await
+    }
 
-	async fn test_database_connection(&self, db: &Database) -> TuxedoResult<()> {
-		db.list_collection_names()
-			.await
-			.expect("Failed to list connections for DB");
-		Ok(())
-	}
+    async fn test_database_connection(&self, db: &Database) -> TuxedoResult<()> {
+        db.list_collection_names()
+            .await
+            .expect("Failed to list connections for DB");
+        Ok(())
+    }
 
-	// Views
+    // Views
 
-	/// Gets the names of all views in the source database
-	pub(crate) async fn get_source_view_names(&self) -> TuxedoResult<Vec<String>> {
-		let views = self.list_source_views().await?;
-		Ok(views.into_iter().map(|view| view.name).collect())
-	}
+    /// Gets the names of all views in the source database
+    pub(crate) async fn get_source_view_names(&self) -> TuxedoResult<Vec<String>> {
+        let views = self.list_source_views().await?;
+        Ok(views.into_iter().map(|view| view.name).collect())
+    }
 
-	/// Lists all views in the source database for copying
-	pub(crate) async fn list_source_views(&self) -> TuxedoResult<Vec<mongodb::results::CollectionSpecification>> {
-		let filter = doc! { "type": "view" };
-		let mut cursor = self.source.list_collections().filter(filter).await?;
-		
-		let mut views = Vec::new();
-		while let Some(collection_spec) = cursor.try_next().await? {
-			// Verify this is actually a view with the required fields
-			if collection_spec.options.view_on.is_some() && collection_spec.options.pipeline.is_some() {
-				views.push(collection_spec);
-			} else {
-				println!(
-					"Warning: Collection '{}' marked as view but missing view fields",
-					collection_spec.name
-				);
-			}
-		}
-		
-		if !views.is_empty() {
-			println!("Found {} views to copy", views.len());
-		}
-		
-		Ok(views)
-	}
+    /// Lists all views in the source database for copying
+    pub(crate) async fn list_source_views(
+        &self,
+    ) -> TuxedoResult<Vec<mongodb::results::CollectionSpecification>> {
+        let filter = doc! { "type": "view" };
+        let mut cursor = self.source.list_collections().filter(filter).await?;
 
-	/// Copies a single view from source to target (used by manager tasks)
-	/// Note: Target views are cleared at startup, so no existence check needed
-	pub(crate) async fn copy_single_view(&self, view_spec: &mongodb::results::CollectionSpecification) -> TuxedoResult<()> {
-		// Extract view information from the CollectionSpecification
-		let view_on = view_spec.options.view_on.as_ref()
-			.ok_or_else(|| TuxedoError::Generic(format!("View '{}' missing viewOn", view_spec.name)))?;
-		
-		let pipeline = view_spec.options.pipeline.as_ref()
-			.ok_or_else(|| TuxedoError::Generic(format!("View '{}' missing pipeline", view_spec.name)))?;
+        let mut views = Vec::new();
+        while let Some(collection_spec) = cursor.try_next().await? {
+            // Verify this is actually a view with the required fields
+            if collection_spec.options.view_on.is_some()
+                && collection_spec.options.pipeline.is_some()
+            {
+                views.push(collection_spec);
+            } else {
+                println!(
+                    "Warning: Collection '{}' marked as view but missing view fields",
+                    collection_spec.name
+                );
+            }
+        }
 
-		// Create the view using the createView command
-		let create_view_command = doc! {
-			"create": &view_spec.name,
-			"viewOn": view_on,
-			"pipeline": pipeline,
-		};
+        if !views.is_empty() {
+            println!("Found {} views to copy", views.len());
+        }
 
-		self.target.run_command(create_view_command).await?;
-		Ok(())
-	}
+        Ok(views)
+    }
+
+    /// Copies a single view from source to target (used by manager tasks)
+    /// Note: Target views are cleared at startup, so no existence check needed
+    pub(crate) async fn copy_single_view(
+        &self,
+        view_spec: &mongodb::results::CollectionSpecification,
+    ) -> TuxedoResult<()> {
+        // Extract view information from the CollectionSpecification
+        let view_on = view_spec.options.view_on.as_ref().ok_or_else(|| {
+            TuxedoError::Generic(format!("View '{}' missing viewOn", view_spec.name))
+        })?;
+
+        let pipeline = view_spec.options.pipeline.as_ref().ok_or_else(|| {
+            TuxedoError::Generic(format!("View '{}' missing pipeline", view_spec.name))
+        })?;
+
+        // Create the view using the createView command
+        let create_view_command = doc! {
+            "create": &view_spec.name,
+            "viewOn": view_on,
+            "pipeline": pipeline,
+        };
+
+        self.target.run_command(create_view_command).await?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ReplicationStrategy {
-	Clone,
-	Mask,
+    Clone,
+    Mask,
 }
 
 impl TryFrom<String> for ReplicationStrategy {
-	type Error = String;
+    type Error = String;
 
-	fn try_from(value: String) -> Result<Self, Self::Error> {
-		match value.to_lowercase().as_str() {
-			"clone" => Ok(Self::Clone),
-			"mask" => Ok(Self::Mask),
-			other => Err(format!(
-				"{} is not a supported replication strategy.",
-				other
-			)),
-		}
-	}
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.to_lowercase().as_str() {
+            "clone" => Ok(Self::Clone),
+            "mask" => Ok(Self::Mask),
+            other => Err(format!(
+                "{} is not a supported replication strategy.",
+                other
+            )),
+        }
+    }
 }


### PR DESCRIPTION
- Introduced `copy_views` method in `ReplicationManagerBuilder` to enable view copying.
- Updated `ReplicationConfig` to include `copy_views` flag, defaulting to false.
- Enhanced `ReplicationManager` to copy views if the `copy_views` flag is enabled, including error handling and logging for view copying.
- Modified collection clearing logic to also drop views when applicable.